### PR TITLE
First step toward static feebumping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43
+          - 1.48
           - nightly
         os:
           - ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -29,16 +29,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "backtrace"
-version = "0.3.62"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091bcdf2da9950f96aa522681ce805e6857f6ca8df73833d35736ab2dc78e152"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -103,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "byteorder"
@@ -115,9 +109,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -136,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -147,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
 dependencies = [
  "signature",
 ]
@@ -168,27 +162,27 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "fern"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
+checksum = "3bdd7b0849075e79ee9a1836df22c717d1eba30451796fdc631b04565dd11e2a"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -197,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -230,15 +224,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jsonrpc"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad24d69a8a0698db8ffb9048e937e8ae3ee3bc45772a5d7b6979b1d2d5b6a9f7"
+checksum = "7f8423b78fc94d12ef1a4a9d13c348c9a78766dda0cc18817adf0faf77e670c8"
 dependencies = [
  "base64-compat",
  "serde",
@@ -248,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libsodium-sys"
@@ -277,36 +271,35 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniscript"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69450033bf162edf854d4aacaff82ca5ef34fa81f6cf69e1c81a103f0834997"
+checksum = "1e292b58407dfbf1384e5aca8428d3b0f2eaa09d24cb17088f6db0b7ca31194a"
 dependencies = [
  "bitcoin",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -330,39 +323,39 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -375,27 +368,28 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
 name = "revault_net"
 version = "0.2.1"
-source = "git+https://github.com/revault/revault_net#7b985bc729bb9c6a0e48f6361ce93f448bfd4283"
+source = "git+https://github.com/revault/revault_net#8b334557a04262dd224f5a42abaf62c26c546dbf"
 dependencies = [
  "bitcoin",
  "log",
@@ -409,7 +403,7 @@ dependencies = [
 [[package]]
 name = "revault_tx"
 version = "0.4.1"
-source = "git+https://github.com/revault/revault_tx#c7e3e29ed37c06196ea241015cfe92c28d1957bf"
+source = "git+https://github.com/revault/revault_tx#23f18b66a0f165a0091e1be8feffe363f37cea97"
 dependencies = [
  "base64",
  "bitcoinconsensus",
@@ -419,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a82b0b91fad72160c56bf8da7a549b25d7c31109f52cc1437eac4c0ad2550a7"
+checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -449,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -474,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
 dependencies = [
  "cc",
 ]
@@ -498,18 +492,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -518,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -529,15 +523,15 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snow"
@@ -572,9 +566,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -582,19 +576,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.8"
+name = "thiserror"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "vcpkg"
@@ -604,9 +618,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/contrib/tools/txbuilder/Cargo.lock
+++ b/contrib/tools/txbuilder/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "bech32",
  "bitcoin_hashes",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -30,6 +31,9 @@ name = "bitcoin_hashes"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoinconsensus"
@@ -42,48 +46,152 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.71"
+name = "byteorder"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ed25519"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+dependencies = [
+ "signature",
+]
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "walkdir",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "miniscript"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69450033bf162edf854d4aacaff82ca5ef34fa81f6cf69e1c81a103f0834997"
+checksum = "1e292b58407dfbf1384e5aca8428d3b0f2eaa09d24cb17088f6db0b7ca31194a"
 dependencies = [
  "bitcoin",
 ]
 
 [[package]]
-name = "revault_tx"
-version = "0.4.0"
+name = "pkg-config"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3e08e97cd866f7f1e4a11ca71604f422d7d6d77ec923fd1c140fb19827e381"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "revault_net"
+version = "0.2.1"
+source = "git+https://github.com/revault/revault_net#f84f411854525c673b27c9ff881b4f0162488a29"
+dependencies = [
+ "bitcoin",
+ "log",
+ "revault_tx",
+ "serde",
+ "serde_json",
+ "snow",
+ "sodiumoxide",
+]
+
+[[package]]
+name = "revault_tx"
+version = "0.4.1"
+source = "git+https://github.com/revault/revault_tx#23f18b66a0f165a0091e1be8feffe363f37cea97"
 dependencies = [
  "base64",
  "bitcoinconsensus",
  "miniscript",
+ "serde",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "secp256k1"
@@ -92,28 +200,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
 dependencies = [
  "cc",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.130"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -121,9 +259,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
+name = "snow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+dependencies = [
+ "byteorder",
+ "rand_core",
+ "rustc_version",
+ "sodiumoxide",
+ "subtle",
+]
+
+[[package]]
+name = "sodiumoxide"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
+dependencies = [
+ "ed25519",
+ "libc",
+ "libsodium-sys",
+ "serde",
+]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "syn"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "txbuilder"
 version = "0.0.1"
 dependencies = [
+ "revault_net",
  "revault_tx",
  "serde_json",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/contrib/tools/txbuilder/Cargo.toml
+++ b/contrib/tools/txbuilder/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"
 
 [dependencies]
-revault_tx = "0.4"
+revault_tx = { git = "https://github.com/revault/revault_tx", features = ["use-serde"] }
+revault_net = { git = "https://github.com/revault/revault_net" }
 serde_json = "1"

--- a/contrib/tools/txbuilder/src/main.rs
+++ b/contrib/tools/txbuilder/src/main.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, env, process, str::FromStr};
 
+use revault_net::message::watchtower::CancelFeerate;
 use revault_tx::{
     bitcoin::{
         consensus::encode::serialize_hex, secp256k1, util::bip32, Address, Amount, OutPoint,
@@ -190,7 +191,6 @@ fn main() {
             eprintln!("Failed to derive transaction chain: '{}'", e);
             process::exit(1);
         });
-    let mut cancel_tx = cancel_batch.into_feerate_20();
     let der_unvault_desc = unvault_desc.derive(derivation_index.into(), &secp);
     let unvault_txin = unvault_tx.spend_unvault_txin(&der_unvault_desc);
     let spend_txo = revault_tx::txouts::SpendTxOut::new(TxOut {
@@ -222,7 +222,15 @@ fn main() {
         })
         .collect();
     let unvault_sigs = sign(&mut unvault_tx, &stk_privkeys, &secp);
-    let cancel_sigs = sign(&mut cancel_tx, &stk_privkeys, &secp);
+    let mut cancel_sigs = BTreeMap::new();
+    let mut cancel_txs = BTreeMap::new();
+    for (feerate, mut cancel_tx) in cancel_batch.feerates_map() {
+        cancel_sigs.insert(
+            CancelFeerate(feerate),
+            sign(&mut cancel_tx, &stk_privkeys, &secp),
+        );
+        cancel_txs.insert(CancelFeerate(feerate), serialize_hex(&cancel_tx.into_tx()));
+    }
     let emer_sigs = sign(&mut emer_tx, &stk_privkeys, &secp);
     let unemer_sigs = sign(&mut unemer_tx, &stk_privkeys, &secp);
     let spend_privkeys: Vec<secp256k1::SecretKey> = man_xprivs
@@ -246,7 +254,7 @@ fn main() {
                 "sigs": unvault_sigs,
             }),
             "cancel": serde_json::json!({
-                "tx": serialize_hex(&cancel_tx.into_tx()),
+                "tx": cancel_txs,
                 "sigs": cancel_sigs,
             }),
             "emer": serde_json::json!({

--- a/contrib/tools/txbuilder/src/main.rs
+++ b/contrib/tools/txbuilder/src/main.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, env, process, str::FromStr};
 use revault_tx::{
     bitcoin::{
         consensus::encode::serialize_hex, secp256k1, util::bip32, Address, Amount, OutPoint,
-        Script, SigHashType, TxOut,
+        Script, TxOut,
     },
     miniscript::{
         descriptor::{Descriptor, DescriptorTrait},
@@ -111,14 +111,13 @@ fn sanity_checks(
 
 fn sign<C: secp256k1::Signing + secp256k1::Verification>(
     psbt: &mut impl RevaultTransaction,
-    sigtype: SigHashType,
     privkeys: &[secp256k1::SecretKey],
     secp: &secp256k1::Secp256k1<C>,
 ) -> BTreeMap<String, String> {
     let mut sigs = BTreeMap::new();
 
     for privkey in privkeys.iter() {
-        let sighash = psbt.signature_hash(0, sigtype).unwrap();
+        let sighash = psbt.signature_hash(0).unwrap();
         let sighash = secp256k1::Message::from_slice(&sighash).unwrap();
         let pubkey = secp256k1::PublicKey::from_secret_key(&secp, &privkey);
         let sig = secp.sign(&sighash, &privkey);
@@ -176,7 +175,7 @@ fn main() {
     let derivation_index: u32 = from_json!(&args[10]);
     sanity_checks(&deposit_desc, &unvault_desc, &cpfp_desc);
 
-    let (mut unvault_tx, mut cancel_tx, mut emer_tx, mut unemer_tx) =
+    let (mut unvault_tx, cancel_batch, mut emer_tx, mut unemer_tx) =
         revault_tx::transactions::transaction_chain(
             deposit_outpoint,
             Amount::from_sat(deposit_value),
@@ -185,13 +184,13 @@ fn main() {
             &cpfp_desc,
             derivation_index.into(),
             emer_address,
-            0,
             &secp,
         )
         .unwrap_or_else(|e| {
             eprintln!("Failed to derive transaction chain: '{}'", e);
             process::exit(1);
         });
+    let mut cancel_tx = cancel_batch.into_feerate_20();
     let der_unvault_desc = unvault_desc.derive(derivation_index.into(), &secp);
     let unvault_txin = unvault_tx.spend_unvault_txin(&der_unvault_desc);
     let spend_txo = revault_tx::txouts::SpendTxOut::new(TxOut {
@@ -204,7 +203,7 @@ fn main() {
         vec![spend_txo],
         None,
         &der_cpfp_desc,
-        0, // FIXME: remove from the API
+        0,
         true,
     )
     .unwrap_or_else(|e| {
@@ -222,30 +221,10 @@ fn main() {
                 .key
         })
         .collect();
-    let unvault_sigs = sign(
-        &mut unvault_tx,
-        SigHashType::All,
-        &stk_privkeys,
-        &secp,
-    );
-    let cancel_sigs = sign(
-        &mut cancel_tx,
-        SigHashType::AllPlusAnyoneCanPay,
-        &stk_privkeys,
-        &secp,
-    );
-    let emer_sigs = sign(
-        &mut emer_tx,
-        SigHashType::AllPlusAnyoneCanPay,
-        &stk_privkeys,
-        &secp,
-    );
-    let unemer_sigs = sign(
-        &mut unemer_tx,
-        SigHashType::AllPlusAnyoneCanPay,
-        &stk_privkeys,
-        &secp,
-    );
+    let unvault_sigs = sign(&mut unvault_tx, &stk_privkeys, &secp);
+    let cancel_sigs = sign(&mut cancel_tx, &stk_privkeys, &secp);
+    let emer_sigs = sign(&mut emer_tx, &stk_privkeys, &secp);
+    let unemer_sigs = sign(&mut unemer_tx, &stk_privkeys, &secp);
     let spend_privkeys: Vec<secp256k1::SecretKey> = man_xprivs
         .iter()
         .map(|xpriv| {
@@ -257,12 +236,7 @@ fn main() {
         })
         .chain(cosig_privkeys.into_iter())
         .collect();
-    sign(
-        &mut spend_tx,
-        SigHashType::All,
-        &spend_privkeys,
-        &secp,
-    );
+    sign(&mut spend_tx, &spend_privkeys, &secp);
 
     println!(
         "{:#}",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+	mock_bitcoind: create a proxy between miradord and bitcoind to mock RPC calls.

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,17 +76,18 @@ fn setup_panic_hook() {
             .unwrap_or_else(|| "'unknown'".to_string());
 
         let bt = backtrace::Backtrace::new();
-        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            log::error!(
-                "panic occurred at line {} of file {}: {:?}\n{:?}",
-                line,
-                file,
-                s,
-                bt
-            );
-        } else {
-            log::error!("panic occurred at line {} of file {}\n{:?}", line, file, bt);
-        }
+        let info = panic_info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| panic_info.payload().downcast_ref::<String>().cloned());
+        log::error!(
+            "panic occurred at line {} of file {}: {:?}\n{:?}",
+            line,
+            file,
+            info,
+            bt
+        );
 
         process::exit(1);
     }));

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -496,7 +496,7 @@ fn new_block(
     // Update the fee-bumping reserves estimates
     // TODO
 
-    // Any vault to forget and feebump coins to unregister?
+    // Any vault to forget about?
     // TODO
 
     // Any Unvault txo confirmed?
@@ -529,17 +529,6 @@ fn new_block(
         revaulted_attempts,
     };
 
-    // Any coin received on the FB wallet?
-    // TODO
-
-    // Any FB coin to be registered for consolidation?
-    // TODO
-
-    // Any consolidation to be processed given the current fee market?
-    // TODO
-
-    // Should the tip have moved under our feet while we cached the updates, we'd have errored by
-    // now. So now it's safe to poll the plugins and update the DB.
     let outpoints_to_revault = get_vaults_to_revault(
         db_path,
         secp,

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -261,10 +261,11 @@ fn revault(
     deposit_desc: &DerivedDepositDescriptor,
 ) -> Result<(), PollerError> {
     // TODO: choose the appropriate one based on feerate
-    let mut cancel_tx = CancelTransaction::new(unvault_txin, &deposit_desc, Amount::from_sat(5))
+    let feerate_vb = Amount::from_sat(20);
+    let mut cancel_tx = CancelTransaction::new(unvault_txin, &deposit_desc, feerate_vb / 4)
         .expect("Can only fail if we have an insane feebumping input");
 
-    for db_sig in db_cancel_signatures(db_path, db_vault.id)? {
+    for db_sig in db_cancel_signatures(db_path, db_vault.id, Some(feerate_vb))? {
         cancel_tx
             .add_sig(db_sig.pubkey, db_sig.signature, secp)
             .unwrap_or_else(|e| {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,7 @@ bip32~=2.0
 pynacl==1.4
 noiseprotocol==0.3.1
 toml==0.10.2
+
+# For the bitcoind proxy
+Flask==2.0.3
+cheroot==8.5.*

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -27,11 +27,11 @@ def test_simple_unvault_broadcast(miradord, bitcoind):
     bitcoind.rpc.sendrawtransaction(txs["unvault"]["tx"])
     bitcoind.generate_block(1, unvault_txid)
 
-    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"])["txid"]
+    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"]["20"])["txid"]
     miradord.wait_for_logs(
         [
             f"Got a confirmed Unvault UTXO for vault at '{deposit_outpoint}'",
-            f"Broadcasted Cancel transaction '{txs['cancel']['tx']}'",
+            f"Broadcasted Cancel transaction '{txs['cancel']['tx']['20']}'",
             f"Unvault transaction '{unvault_txid}' for vault at '{deposit_outpoint}' is still unspent",
         ]
     )
@@ -65,11 +65,11 @@ def test_spent_cancel_detection(miradord, bitcoind):
     unvault_txid = bitcoind.rpc.decoderawtransaction(txs["unvault"]["tx"])["txid"]
     bitcoind.rpc.sendrawtransaction(txs["unvault"]["tx"])
     bitcoind.generate_block(1, unvault_txid)
-    cancel_tx = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"])
+    cancel_tx = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"]["20"])
     miradord.wait_for_logs(
         [
             f"Got a confirmed Unvault UTXO for vault at '{deposit_outpoint}'",
-            f"Broadcasted Cancel transaction '{txs['cancel']['tx']}'",
+            f"Broadcasted Cancel transaction '{txs['cancel']['tx']['20']}'",
             f"Unvault transaction '{unvault_txid}' for vault at '{deposit_outpoint}' is still unspent",
         ]
     )

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -215,9 +215,7 @@ class Miradord(TailableProc):
         params = {
             "signatures": {
                 "emergency": emer_sigs,
-                "cancel": {
-                    "20": cancel_sigs,
-                },
+                "cancel": cancel_sigs,
                 "unvault_emergency": unemer_sigs,
             },
             "deposit_outpoint": deposit_outpoint,

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -215,7 +215,9 @@ class Miradord(TailableProc):
         params = {
             "signatures": {
                 "emergency": emer_sigs,
-                "cancel": cancel_sigs,
+                "cancel": {
+                    "20": cancel_sigs,
+                },
                 "unvault_emergency": unemer_sigs,
             },
             "deposit_outpoint": deposit_outpoint,

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -36,7 +36,8 @@ class Miradord(TailableProc):
         stk_noise_secret,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpcport,
+        bitcoind_cookie,
         plugins=[],
     ):
         TailableProc.__init__(self, datadir, verbose=VERBOSE)
@@ -49,7 +50,6 @@ class Miradord(TailableProc):
         self.unvault_desc = unvault_desc
         self.cpfp_desc = cpfp_desc
         self.emer_addr = emer_addr
-        self.bitcoind = bitcoind
 
         # The data is stored in a per-network directory. We need to create it
         # in order to write the Noise private key
@@ -71,7 +71,6 @@ class Miradord(TailableProc):
             f"Watchtower Noise key: {wt_noise_key.hex()}, Stakeholder Noise key: {stk_noise_key.hex()}"
         )
 
-        bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
         with open(self.conf_file, "w") as f:
             f.write(f"data_dir = '{datadir}'\n")
             f.write("daemon = false\n")
@@ -94,7 +93,7 @@ class Miradord(TailableProc):
             f.write("[bitcoind_config]\n")
             f.write('network = "regtest"\n')
             f.write(f"cookie_path = '{bitcoind_cookie}'\n")
-            f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
+            f.write(f"addr = '127.0.0.1:{bitcoind_rpcport}'\n")
             f.write("poll_interval_secs = 5\n")
 
             f.write(f"\n{toml.dumps({'plugins': plugins})}\n")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -64,11 +64,11 @@ def test_max_value_in_flight(miradord, bitcoind):
     unvault_txid = bitcoind.rpc.decoderawtransaction(txs["unvault"]["tx"])["txid"]
     bitcoind.rpc.sendrawtransaction(txs["unvault"]["tx"])
     bitcoind.generate_block(1, unvault_txid)
-    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"])["txid"]
+    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"]["20"])["txid"]
     miradord.wait_for_logs(
         [
             f"Got a confirmed Unvault UTXO for vault at '{deposit_outpoint}'",
-            f"Broadcasted Cancel transaction '{txs['cancel']['tx']}'",
+            f"Broadcasted Cancel transaction '{txs['cancel']['tx']['20']}'",
             f"Unvault transaction '{unvault_txid}' for vault at '{deposit_outpoint}' is still unspent",
         ]
     )
@@ -163,11 +163,11 @@ def test_multiple_plugins(miradord, bitcoind):
     unvault_txid = bitcoind.rpc.decoderawtransaction(txs["unvault"]["tx"])["txid"]
     bitcoind.rpc.sendrawtransaction(txs["unvault"]["tx"])
     bitcoind.generate_block(1, unvault_txid)
-    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"])["txid"]
+    cancel_txid = bitcoind.rpc.decoderawtransaction(txs["cancel"]["tx"]["20"])["txid"]
     miradord.wait_for_logs(
         [
             f"Got a confirmed Unvault UTXO for vault at '{deposit_outpoint}'",
-            f"Broadcasted Cancel transaction '{txs['cancel']['tx']}'",
+            f"Broadcasted Cancel transaction '{txs['cancel']['tx']['20']}'",
             f"Unvault transaction '{unvault_txid}' for vault at '{deposit_outpoint}' is still unspent",
         ]
     )


### PR DESCRIPTION
This implements https://github.com/revault/practical-revault/pull/119. 

We start by adapting the listener to the new messages, and make it treat incoming Cancel signatures for the various Cancel transactions (where it previously only had to manage for a single one).
We continue by adapting the poller loop to choose the correct Cancel transaction to broadcast depending on the fee estimates. This is only a first step, more needs to be considered for a proper fee bumping integration.
Finally, we get rid of the fee bumping wallet mentions: we are not doing that anymore (for the time being).