### PR TITLE
bump revault_net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,8 +389,7 @@ dependencies = [
 [[package]]
 name = "revault_net"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cf3a2aec4c7afc9900d88eed6ef84272fcd78f2f36c69a46146cdb233d57f6"
+source = "git+https://github.com/edouardparis/revault_net?branch=Add-timeout-to-transport-send_req#1549523a18c8286ce38983a9fd90d10a35216add"
 dependencies = [
  "bitcoin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 revault_tx = { version = "0.5", features = ["use-serde"] }
-revault_net = "0.3"
+revault_net = { git = "https://github.com/edouardparis/revault_net", branch = "Add-timeout-to-transport-send_req" }
 
 # Don't reinvent the wheel
 dirs = "3.0"


### PR DESCRIPTION
A updated version of revault_net with request timeout is necessary because of the need to communicate with a untrusted coordinator